### PR TITLE
Initialize hue and saturation

### DIFF
--- a/NKOColorPickerView.m
+++ b/NKOColorPickerView.m
@@ -126,7 +126,8 @@ CGFloat const NKOPickerViewCrossHairshWidthAndHeight    = 38.f;
 
 - (void)setColor:(UIColor *)newColor
 {
-    CGFloat hue, saturation;
+    CGFloat hue = 0.f;
+    CGFloat saturation = 0.f;
     [newColor getHue:&hue saturation:&saturation brightness:nil alpha:nil];
 
     currentHue = hue;


### PR DESCRIPTION
You can't rely for the compiler to initialize hue and saturation float automatically.
After a few calls to `- getHue:saturation:brightness:alpha:` with a nil `newColor` they appear to be not allocated and writing to them results to NaN which later on leads to a crash when caculating layer position.
